### PR TITLE
Add Windows and Tabs Updater

### DIFF
--- a/packages/electron-chrome-extensions/README.md
+++ b/packages/electron-chrome-extensions/README.md
@@ -211,6 +211,18 @@ Example:
 }
 ```
 
+##### `extensions.windowUpdated(window)`
+
+- `window` Electron.BrowserWindow
+
+Update the details of a window from the main process.
+
+##### `extensions.tabUpdated(tab)`
+
+- `tab` Electron.WebContents
+
+Update the details of a tab from the main process.
+
 #### Instance Events
 
 ##### Event: 'browser-action-popup-created'

--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -123,6 +123,12 @@ export class TabsAPI {
     }
 
     this.ctx.store.tabDetailsCache.set(tab.id, details)
+
+    // Update the window's tab cache
+    if (win) {
+      this.ctx.store.updateWindowDetails(win)
+    }
+
     return details
   }
 

--- a/packages/electron-chrome-extensions/src/browser/api/windows.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/windows.ts
@@ -27,6 +27,7 @@ export class WindowsAPI {
     handle('windows.remove', this.remove.bind(this))
 
     this.ctx.store.on('window-added', this.observeWindow.bind(this))
+    this.ctx.store.on('update-window-details', this.updateWindowDetails.bind(this))
   }
 
   private observeWindow(window: Electron.BrowserWindow) {
@@ -66,7 +67,7 @@ export class WindowsAPI {
         })
         .map((tab) => this.ctx.store.tabDetailsCache.get(tab.id) as chrome.tabs.Tab)
         .filter(Boolean),
-      incognito: this.ctx.session.isPersistent(),
+      incognito: !this.ctx.session.isPersistent(),
       type: 'normal', // TODO
       state: getWindowState(win),
       alwaysOnTop: win.isAlwaysOnTop(),
@@ -81,6 +82,11 @@ export class WindowsAPI {
     if (this.ctx.store.windowDetailsCache.has(win.id)) {
       return this.ctx.store.windowDetailsCache.get(win.id)
     }
+    const details = this.createWindowDetails(win)
+    return details
+  }
+
+  public updateWindowDetails(win: Electron.BaseWindow) {
     const details = this.createWindowDetails(win)
     return details
   }

--- a/packages/electron-chrome-extensions/src/browser/index.ts
+++ b/packages/electron-chrome-extensions/src/browser/index.ts
@@ -213,6 +213,19 @@ export class ElectronChromeExtensions extends EventEmitter {
     }
   }
 
+  windowUpdated(window: Electron.BaseWindow) {
+    return this.api.windows.updateWindowDetails(window)
+  }
+
+  tabUpdated(tab: Electron.WebContents) {
+    this.checkWebContentsArgument(tab)
+    if (this.ctx.store.tabs.has(tab)) {
+      this.api.tabs.onUpdated(tab.id)
+      return true
+    }
+    return false
+  }
+
   /**
    * Add webContents to be tracked as an extension host which will receive
    * extension events when a chrome-extension:// resource is loaded.

--- a/packages/electron-chrome-extensions/src/browser/store.ts
+++ b/packages/electron-chrome-extensions/src/browser/store.ts
@@ -206,4 +206,8 @@ export class ExtensionStore extends EventEmitter {
     const result: unknown = await this.impl.requestPermissions(extension, permissions)
     return typeof result === 'boolean' ? result : false
   }
+
+  updateWindowDetails(win: Electron.BaseWindow) {
+    this.emit('update-window-details', win)
+  }
 }


### PR DESCRIPTION
## Added

- `extensions.windowUpdated(window)` - Update the details of a window from the main process.
- `extensions.tabUpdated(tab)` - Update the details of a tab from the main process.

## Fixes

- Fixed incognito property of windows not being accurate (Flipped it)
- Fixed `windowDetailsCache` not updating its `tabs` property.

<!-- Please include a description of changes. -->

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
