### PR TITLE
feat: expose handleCrxRequest()

### DIFF
--- a/packages/electron-chrome-extensions/README.md
+++ b/packages/electron-chrome-extensions/README.md
@@ -134,6 +134,7 @@ module.exports = {
      Valid options include `GPL-3.0`, `Patron-License-2020-11-19`
   - `session` Electron.Session (optional) - Session which should support
     Chrome extension APIs. `session.defaultSession` is used by default.
+  - `registerCrxProtocolInDefaultSession` Boolean (optional) - Whether to register the 'crx://' protocol in the default session. Defaults to `true`.
   - `createTab(details) => Promise<[Electron.WebContents, Electron.BrowserWindow]>` (optional) -
     Called when `chrome.tabs.create` is invoked by an extension. Allows the
     application to handle how tabs are created.
@@ -222,6 +223,14 @@ Update the details of a window from the main process.
 - `tab` Electron.WebContents
 
 Update the details of a tab from the main process.
+
+##### `extensions.handleCrxRequest(request)`
+
+- `request` GlobalRequest
+
+Handle a request to the 'crx://' protocol.
+
+Returns `GlobalResponse`
 
 #### Instance Events
 

--- a/packages/electron-chrome-extensions/README.md
+++ b/packages/electron-chrome-extensions/README.md
@@ -20,6 +20,9 @@ npm install electron-chrome-extensions
 
 ## Usage
 
+> [!IMPORTANT]  
+> You must initialize the `ElectronChromeExtensions` class before installing any extensions, otherwise it might not work as expected.
+
 ### Basic
 
 Simple browser using Electron's [default session](https://www.electronjs.org/docs/api/session#sessiondefaultsession) and one tab.

--- a/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/browser-action.ts
@@ -219,7 +219,7 @@ export class BrowserActionAPI {
     }
   }
 
-  private handleCrxRequest = (request: GlobalRequest): GlobalResponse => {
+  handleCrxRequest = (request: GlobalRequest): GlobalResponse => {
     d('%s', request.url)
 
     try {

--- a/packages/electron-chrome-extensions/src/browser/index.ts
+++ b/packages/electron-chrome-extensions/src/browser/index.ts
@@ -74,6 +74,12 @@ export interface ChromeExtensionOptions extends ChromeExtensionImpl {
    * @deprecated See "Packaging the preload script" in the readme.
    */
   modulePath?: string
+
+  /**
+   * Whether to register the 'crx://' protocol in the default session.
+   * Defaults to `true`.
+   */
+  registerCrxProtocolInDefaultSession?: boolean
 }
 
 const sessionMap = new WeakMap<Electron.Session, ElectronChromeExtensions>()
@@ -143,7 +149,10 @@ export class ElectronChromeExtensions extends EventEmitter {
     this.prependPreload(opts.modulePath)
 
     // Register crx:// protocol in default session for convenience
-    if (this.ctx.session !== electronSession.defaultSession) {
+    if (
+      opts.registerCrxProtocolInDefaultSession !== false &&
+      this.ctx.session !== electronSession.defaultSession
+    ) {
       this.handleCRXProtocol(electronSession.defaultSession)
     }
   }
@@ -263,6 +272,13 @@ export class ElectronChromeExtensions extends EventEmitter {
    */
   handleCRXProtocol(session: Electron.Session) {
     this.api.browserAction.handleCRXProtocol(session)
+  }
+
+  /**
+   * Handles the 'crx://' protocol in the session.
+   */
+  handleCrxRequest(request: GlobalRequest): GlobalResponse {
+    return this.api.browserAction.handleCrxRequest(request)
   }
 
   /**


### PR DESCRIPTION
<!-- Please include a description of changes. -->

## Changes

- Added `extensions.handleCrxRequest()`
- Added option `registerCrxProtocolInDefaultSession` when creating an `ElectronChromeExtensions` instance
- Update README to include initialization warning

---

## Problem

When having multiple sessions with multiple instances of `ElectronChromeExtensions`, using `crx` in the default session will only result in one of the session's extension icons being able to load.

## Solutions

- Expose `extensions.handleCrxRequest()` to allow custom handling
- Add an option to prevent handling it automatically in default session.

## Sample Code

```ts
// Register CRX protocol in default session
app.whenReady().then(() => {
  protocol.handle("crx", async (request) => {
    const url = URL.parse(request.url);
    if (!url) {
      return new Response("Invalid URL", { status: 404 });
    }

    const partition = url?.searchParams.get("partition");
    if (!partition) {
      return new Response("No partition", { status: 400 });
    }

    const partitionSession = session.fromPartition(partition);

    const extensions = ElectronChromeExtensions.fromSession(partitionSession);
    if (!extensions) {
      return new Response("Extensions not found", { status: 404 });
    }

    return extensions.handleCrxRequest(request);
  });
});
```

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
