### PR TITLE
Improved Web Store Management

### DIFF
--- a/packages/electron-chrome-web-store/README.md
+++ b/packages/electron-chrome-web-store/README.md
@@ -102,7 +102,7 @@ Installs Chrome Web Store support in the specified session.
   - `beforeInstall`: A function which receives install details and returns a promise. Allows for prompting prior to install.
   - `afterInstall`: A function which receives install details. Allows for additional actions after install.
   - `afterUninstall`: A function which receives extension ID, extension, and manifest. Allows for additional actions after uninstall.
-  - `overrideExtensionInstallStatus`: A function which receives the current state, extension ID, and manifest. Returns a string indicating the install status of the extension.
+  - `overrideExtensionInstallStatus`: A function which receives the current state, extension ID, and manifest. Returns a string indicating the install status of the extension, or returns undefined to fallback to the default install status.
 
 ### `installExtension`
 

--- a/packages/electron-chrome-web-store/README.md
+++ b/packages/electron-chrome-web-store/README.md
@@ -100,6 +100,9 @@ Installs Chrome Web Store support in the specified session.
   - `allowlist`: An array of allowed extension IDs to install.
   - `denylist`: An array of denied extension IDs to install.
   - `beforeInstall`: A function which receives install details and returns a promise. Allows for prompting prior to install.
+  - `afterInstall`: A function which receives install details. Allows for additional actions after install.
+  - `afterUninstall`: A function which receives extension ID, extension, and manifest. Allows for additional actions after uninstall.
+  - `overrideExtensionInstallStatus`: A function which receives the current state, extension ID, and manifest. Returns a string indicating the install status of the extension.
 
 ### `installExtension`
 

--- a/packages/electron-chrome-web-store/src/browser/api.ts
+++ b/packages/electron-chrome-web-store/src/browser/api.ts
@@ -338,6 +338,9 @@ export function registerWebStoreApi(webStoreState: WebStoreState) {
 
   handle('chrome.management.setEnabled', async (event, id, enabled) => {
     // TODO: Implement enabling/disabling extension
+    if (webStoreState.customSetExtensionEnabled) {
+      await webStoreState.customSetExtensionEnabled(webStoreState, id, enabled)
+    }
     return true
   })
 

--- a/packages/electron-chrome-web-store/src/browser/index.ts
+++ b/packages/electron-chrome-web-store/src/browser/index.ts
@@ -10,7 +10,16 @@ export { installExtension, uninstallExtension, downloadExtension } from './insta
 import { initUpdater } from './updater'
 export { updateExtensions } from './updater'
 import { getDefaultExtensionsPath } from './utils'
-import { BeforeInstall, ExtensionId, WebStoreState } from './types'
+import {
+  BeforeInstall,
+  AfterInstall,
+  ExtensionId,
+  WebStoreState,
+  OverrideExtensionInstallStatus,
+  AfterUninstall,
+} from './types'
+import { ExtensionInstallStatus } from '../common/constants'
+export { ExtensionInstallStatus }
 
 function resolvePreloadPath(modulePath?: string) {
   // Attempt to resolve preload path from module exports
@@ -97,6 +106,21 @@ interface ElectronChromeWebStoreOptions {
    * to be taken.
    */
   beforeInstall?: BeforeInstall
+
+  /**
+   * Called when determining the install status of an extension.
+   */
+  overrideExtensionInstallStatus?: OverrideExtensionInstallStatus
+
+  /**
+   * Called after an extension is installed.
+   */
+  afterInstall?: AfterInstall
+
+  /**
+   * Called after an extension is uninstalled.
+   */
+  afterUninstall?: AfterUninstall
 }
 
 /**
@@ -114,6 +138,12 @@ export async function installChromeWebStore(opts: ElectronChromeWebStoreOptions 
   const minimumManifestVersion =
     typeof opts.minimumManifestVersion === 'number' ? opts.minimumManifestVersion : 3
   const beforeInstall = typeof opts.beforeInstall === 'function' ? opts.beforeInstall : undefined
+  const afterInstall = typeof opts.afterInstall === 'function' ? opts.afterInstall : undefined
+  const afterUninstall = typeof opts.afterUninstall === 'function' ? opts.afterUninstall : undefined
+  const overrideExtensionInstallStatus =
+    typeof opts.overrideExtensionInstallStatus === 'function'
+      ? opts.overrideExtensionInstallStatus
+      : undefined
 
   const webStoreState: WebStoreState = {
     session,
@@ -123,6 +153,9 @@ export async function installChromeWebStore(opts: ElectronChromeWebStoreOptions 
     denylist: opts.denylist ? new Set(opts.denylist) : undefined,
     minimumManifestVersion,
     beforeInstall,
+    afterInstall,
+    afterUninstall,
+    overrideExtensionInstallStatus,
   }
 
   // Add preload script to session

--- a/packages/electron-chrome-web-store/src/browser/index.ts
+++ b/packages/electron-chrome-web-store/src/browser/index.ts
@@ -17,6 +17,7 @@ import {
   WebStoreState,
   OverrideExtensionInstallStatus,
   AfterUninstall,
+  CustomSetExtensionEnabled,
 } from './types'
 import { ExtensionInstallStatus } from '../common/constants'
 export { ExtensionInstallStatus }
@@ -108,6 +109,11 @@ interface ElectronChromeWebStoreOptions {
   beforeInstall?: BeforeInstall
 
   /**
+   * Called when setting the enabled status of an extension.
+   */
+  customSetExtensionEnabled?: CustomSetExtensionEnabled
+
+  /**
    * Called when determining the install status of an extension.
    */
   overrideExtensionInstallStatus?: OverrideExtensionInstallStatus
@@ -137,9 +143,16 @@ export async function installChromeWebStore(opts: ElectronChromeWebStoreOptions 
   const autoUpdate = typeof opts.autoUpdate === 'boolean' ? opts.autoUpdate : true
   const minimumManifestVersion =
     typeof opts.minimumManifestVersion === 'number' ? opts.minimumManifestVersion : 3
+
   const beforeInstall = typeof opts.beforeInstall === 'function' ? opts.beforeInstall : undefined
   const afterInstall = typeof opts.afterInstall === 'function' ? opts.afterInstall : undefined
   const afterUninstall = typeof opts.afterUninstall === 'function' ? opts.afterUninstall : undefined
+
+  const customSetExtensionEnabled =
+    typeof opts.customSetExtensionEnabled === 'function'
+      ? opts.customSetExtensionEnabled
+      : undefined
+
   const overrideExtensionInstallStatus =
     typeof opts.overrideExtensionInstallStatus === 'function'
       ? opts.overrideExtensionInstallStatus
@@ -155,6 +168,7 @@ export async function installChromeWebStore(opts: ElectronChromeWebStoreOptions 
     beforeInstall,
     afterInstall,
     afterUninstall,
+    customSetExtensionEnabled,
     overrideExtensionInstallStatus,
   }
 

--- a/packages/electron-chrome-web-store/src/browser/types.ts
+++ b/packages/electron-chrome-web-store/src/browser/types.ts
@@ -13,6 +13,20 @@ export type BeforeInstall = (
   details: ExtensionInstallDetails,
 ) => Promise<{ action: 'allow' | 'deny' }>
 
+export type AfterInstall = (details: ExtensionInstallDetails) => Promise<void>
+
+export type AfterUninstall = (details: {
+  id: ExtensionId
+  extension?: Electron.Extension
+  manifest?: chrome.runtime.Manifest
+}) => Promise<void>
+
+export type OverrideExtensionInstallStatus = (
+  state: WebStoreState,
+  extensionId: ExtensionId,
+  manifest?: chrome.runtime.Manifest,
+) => string | undefined
+
 export interface WebStoreState {
   session: Electron.Session
   extensionsPath: string
@@ -21,4 +35,7 @@ export interface WebStoreState {
   denylist?: Set<ExtensionId>
   minimumManifestVersion: number
   beforeInstall?: BeforeInstall
+  afterInstall?: AfterInstall
+  afterUninstall?: AfterUninstall
+  overrideExtensionInstallStatus?: OverrideExtensionInstallStatus
 }

--- a/packages/electron-chrome-web-store/src/browser/types.ts
+++ b/packages/electron-chrome-web-store/src/browser/types.ts
@@ -21,6 +21,12 @@ export type AfterUninstall = (details: {
   manifest?: chrome.runtime.Manifest
 }) => Promise<void>
 
+export type CustomSetExtensionEnabled = (
+  state: WebStoreState,
+  extensionId: ExtensionId,
+  enabled: boolean,
+) => Promise<void>
+
 export type OverrideExtensionInstallStatus = (
   state: WebStoreState,
   extensionId: ExtensionId,
@@ -37,5 +43,6 @@ export interface WebStoreState {
   beforeInstall?: BeforeInstall
   afterInstall?: AfterInstall
   afterUninstall?: AfterUninstall
+  customSetExtensionEnabled?: CustomSetExtensionEnabled
   overrideExtensionInstallStatus?: OverrideExtensionInstallStatus
 }


### PR DESCRIPTION
<!-- Please include a description of changes. -->

## Summary

This PR makes it possible for users to create a custom extensions management system (Install, Uninstall, Enable & Disable)

---

## Changes

- Added an `afterInstall` option to `installChromeWebStore()`, which allows the users to specifically track extensions installed via the webstore.
- Added an `afterUninstall` option to `installChromeWebStore()`, which allows the users to specifically track extensions uninstalled via the webstore
- Added an `overrideExtensionInstallStatus` option to `installChromeWebStore()`, which allows the users to override the extension state passed to the webstore. (eg: Disabled, Blacklisted, Corrupted, etc)

## Why?

These changes allowed me to implement a custom extension management system, while maintaining the state with `electron-chrome-web-store`.

---

<!-- Please leave the message below as-is to accept this project's CLA. -->

✅ By sending this pull request, I agree to the [Contributor License Agreement](https://github.com/samuelmaddock/electron-browser-shell#contributor-license-agreement) of this project.
